### PR TITLE
Updating tasks/main.yml to fix 'must be stored as a dictionary/hash' …

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,9 +20,9 @@
 
 - include_vars: "{{ item }}"
   with_first_found:
-    - "{{ ansible_os_family }}-{{ ansible_distribution_release }}.yml"
-    - "{{ ansible_os_family }}.yml"
-    - default.yml
+    - "vars/{{ ansible_os_family }}-{{ ansible_distribution_release }}.yml"
+    - "vars/{{ ansible_os_family }}.yml"
+    - "vars/default.yml"
 
 - name: Configure New Relic PHP Agent
   template:


### PR DESCRIPTION
Fix for issue #6 

Ansible 2.0.1.0 was trying to load a task as a var file and therefore complaining about the format. The fix is to be more explicit about which file should be loaded.
